### PR TITLE
Handling secure (https and wss) connections.

### DIFF
--- a/session.go
+++ b/session.go
@@ -21,7 +21,11 @@ type Session struct {
 // NewSession receives the configuraiton variables from the socket.io
 // server.
 func NewSession(url string) (*Session, error) {
-	response, err := http.Get("http://" + url + "/socket.io/1")
+	urlParser, err := NewUrlParser(url)
+	if err != nil {
+		return nil, err
+	}
+	response, err := http.Get(urlParser.Handshake())
 	if err != nil {
 		return nil, err
 	}
@@ -60,3 +64,4 @@ func (session *Session) SupportProtocol(protocol string) bool {
 	}
 	return false
 }
+

--- a/transport.go
+++ b/transport.go
@@ -28,7 +28,11 @@ type WSTransport struct {
 }
 
 func NewWSTransport(session *Session, url string) (*WSTransport, error) {
-	ws, err := websocket.Dial("ws://"+url+"/socket.io/1/websocket/"+session.ID, "", "http://localhost/")
+	urlParser, err := NewUrlParser(url)
+	if err != nil {
+		return nil, err
+	}
+	ws, err := websocket.Dial(urlParser.Websocket(session.ID), "", "http://localhost/")
 	if err != nil {
 		return nil, err
 	}

--- a/url_parser.go
+++ b/url_parser.go
@@ -1,0 +1,38 @@
+package socketio
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Parse raw url string and make valid handshake or websockets socket.io url.
+type UrlParser struct {
+	raw    string
+	parsed *url.URL
+}
+
+func NewUrlParser(raw string) (*UrlParser, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	if parsed.Scheme == "" {
+		parsed.Scheme = "http"
+	}
+	return &UrlParser{raw: raw, parsed: parsed}, nil
+}
+
+func (u *UrlParser) Handshake() string {
+	return fmt.Sprintf("%s/socket.io/1", u.parsed.String())
+}
+
+func (u *UrlParser) Websocket(sessionId string) string {
+	var host string
+	if u.parsed.Scheme == "https" {
+		host = strings.Replace(u.parsed.String(), "https://", "wss://", 1)
+	} else {
+		host = strings.Replace(u.parsed.String(), "http://", "ws://", 1)
+	}
+	return fmt.Sprintf("%s/socket.io/1/websocket/%s", host, sessionId)
+}

--- a/url_parser_test.go
+++ b/url_parser_test.go
@@ -1,0 +1,58 @@
+package socketio
+
+import (
+	"testing"
+)
+
+func testHandshakeUrls(t *testing.T, rawUrls []string, expected string) {
+	for _, raw := range rawUrls {
+		u, err := NewUrlParser(raw)
+		if err != nil {
+			t.Errorf("NewUrl error:  %s", err)
+		}
+		if u.Handshake() != expected {
+			t.Errorf("Wrong handshake formatted url, expected: %s, actual: %s", expected, u.Handshake())
+		}
+	}
+}
+
+func testWebsocketUrls(t *testing.T, rawUrls []string, expected string) {
+	for _, raw := range rawUrls {
+		u, err := NewUrlParser(raw)
+		if err != nil {
+			t.Errorf("NewUrl error:  %s", err)
+		}
+		ws := u.Websocket("session_id")
+		if ws != expected {
+			t.Errorf("Wrong websocket formatted url, expected: %s, actual: %s", expected, ws)
+		}
+	}
+}
+
+func TestHandshakeUrl(t *testing.T) {
+	testHandshakeUrls(t,
+		[]string{"server.com", "http://server.com"},
+		"http://server.com/socket.io/1")
+
+	testHandshakeUrls(t,
+		[]string{"server.com/path", "http://server.com/path"},
+		"http://server.com/path/socket.io/1")
+
+	testHandshakeUrls(t,
+		[]string{"https://server.com"},
+		"https://server.com/socket.io/1")
+}
+
+func TestWebsocketUrl(t *testing.T) {
+	testWebsocketUrls(t,
+		[]string{"server.com", "http://server.com"},
+		"ws://server.com/socket.io/1/websocket/session_id")
+
+	testWebsocketUrls(t,
+		[]string{"server.com/path", "http://server.com/path"},
+		"ws://server.com/path/socket.io/1/websocket/session_id")
+
+	testWebsocketUrls(t,
+		[]string{"https://server.com"},
+		"wss://server.com/socket.io/1/websocket/session_id")
+}


### PR DESCRIPTION
I had to connect to the socket.io server over https. 
Url in DialAndConnect can now include scheme; http or https.

```
socket, err := DialAndConnect("https://localhost:12345", "/channel", "key=value")
```

If https scheme is used websocket connections will use wss scheme.
